### PR TITLE
annotated-wl-pprint does not build with GHC 7.10.1

### DIFF
--- a/Text/PrettyPrint/Annotated/Leijen.hs
+++ b/Text/PrettyPrint/Annotated/Leijen.hs
@@ -54,6 +54,7 @@ module Text.PrettyPrint.Annotated.Leijen (
 ) where
 
 import System.IO (Handle,hPutStr,hPutChar,stdout)
+import Prelude hiding ((<$>))
 
 infixr 5 </>,<//>,<$>,<$$>
 infixr 6 <>,<+>


### PR DESCRIPTION
Building `annotated-wl-pprint` with GHC 7.10.1 results in:

```
Text/PrettyPrint/Annotated/Leijen.hs:214:24:
    Ambiguous occurrence ‘<$>’
    It could refer to either ‘Text.PrettyPrint.Annotated.Leijen.<$>’,
                             defined at Text/PrettyPrint/Annotated/Leijen.hs:273:3
                          or ‘Prelude.<$>’,
                             imported from ‘Prelude’ at Text/PrettyPrint/Annotated/Leijen.hs:1:8-40
                             (and originally defined in ‘Data.Functor’
```