### PR TITLE
Fix compilation with GHC 7.0.4/base-4.3

### DIFF
--- a/Text/PrettyPrint/Annotated/Leijen.hs
+++ b/Text/PrettyPrint/Annotated/Leijen.hs
@@ -60,7 +60,7 @@ import Data.String
 import Prelude ((.), ($), (/=), (<), (<=), (>), (>=), (-), (*), (+), (++),
                 Bool(..), Char, Double, Float, Functor, Int, Integer, IO, Rational, Show, ShowS,
                 id, error, flip, foldr1, fromIntegral, length, max, min, otherwise, repeat, replicate,
-                return, round, seq, show, showChar, showString, showsPrec, span, zipWith)
+                return, round, seq, String, show, showChar, showString, showsPrec, span, zipWith)
 
 import Control.Applicative (Applicative(..), liftA2)
 import Data.Monoid (Monoid(..))


### PR DESCRIPTION
This fixes the compile failure

```
[1 of 1] Compiling Text.PrettyPrint.Annotated.Leijen ( Text/PrettyPrint/Annotated/Leijen.hs, /tmp/annotated-wl-pprint/dist-newstyle/build/x86_64-linux/ghc-7.0.4/annotated-wl-pprint-0.7.0/build/Text/PrettyPrint/Annotated/Leijen.o )

Text/PrettyPrint/Annotated/Leijen.hs:413:11-16:
    Not in scope: type constructor or class `String'

Text/PrettyPrint/Annotated/Leijen.hs:597:28-33:
    Not in scope: type constructor or class `String'

Text/PrettyPrint/Annotated/Leijen.hs:619:29-34:
    Not in scope: type constructor or class `String'

Text/PrettyPrint/Annotated/Leijen.hs:642:9-14:
    Not in scope: type constructor or class `String'

Text/PrettyPrint/Annotated/Leijen.hs:818:27-32:
    Not in scope: type constructor or class `String'

Text/PrettyPrint/Annotated/Leijen.hs:851:33-38:
    Not in scope: type constructor or class `String'

Text/PrettyPrint/Annotated/Leijen.hs:853:57-62:
    Not in scope: type constructor or class `String'

Text/PrettyPrint/Annotated/Leijen.hs:873:27-32:
    Not in scope: type constructor or class `String'

Text/PrettyPrint/Annotated/Leijen.hs:873:37-42:
    Not in scope: type constructor or class `String'

Text/PrettyPrint/Annotated/Leijen.hs:873:63-68:
    Not in scope: type constructor or class `String'

Text/PrettyPrint/Annotated/Leijen.hs:887:23-28:
    Not in scope: type constructor or class `String'
```
